### PR TITLE
Add arm64 support for key languages

### DIFF
--- a/packages/go/1.16.2/build.sh
+++ b/packages/go/1.16.2/build.sh
@@ -1,5 +1,20 @@
 #!/usr/bin/env bash
-curl -LO https://golang.org/dl/go1.16.2.linux-amd64.tar.gz
-tar -xzf go1.16.2.linux-amd64.tar.gz
-rm go1.16.2.linux-amd64.tar.gz
+set -e
+
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64)
+        GO_ARCH="amd64"
+        ;;
+    aarch64|arm64)
+        GO_ARCH="arm64"
+        ;;
+    *)
+        GO_ARCH="$ARCH"
+        ;;
+esac
+
+curl -LO "https://golang.org/dl/go1.16.2.linux-${GO_ARCH}.tar.gz"
+tar -xzf go1.16.2.linux-${GO_ARCH}.tar.gz
+rm go1.16.2.linux-${GO_ARCH}.tar.gz
 

--- a/packages/haskell/9.0.1/build.sh
+++ b/packages/haskell/9.0.1/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 PREFIX=$(realpath $(dirname $0))
 
@@ -6,8 +7,21 @@ mkdir -p build
 
 cd build
 
-# Platform specific because a true source compile would require GHC to be installed already on the latest
-curl -L "https://downloads.haskell.org/~ghc/9.0.1/ghc-9.0.1-x86_64-deb10-linux.tar.xz" -o ghc.tar.xz
+# Platform specific because a true source compile would require GHC preinstalled
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64)
+        GHC_ARCH="x86_64"
+        ;;
+    aarch64|arm64)
+        GHC_ARCH="aarch64"
+        ;;
+    *)
+        GHC_ARCH="$ARCH"
+        ;;
+esac
+
+curl -L "https://downloads.haskell.org/~ghc/9.0.1/ghc-9.0.1-${GHC_ARCH}-deb10-linux.tar.xz" -o ghc.tar.xz
 tar xf ghc.tar.xz --strip-components=1
 rm ghc.tar.xz
 

--- a/packages/node/15.10.0/build.sh
+++ b/packages/node/15.10.0/build.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
-curl "https://nodejs.org/dist/v15.10.0/node-v15.10.0-linux-x64.tar.xz" -o node.tar.xz
+set -e
+
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64)
+        NODE_ARCH="x64"
+        ;;
+    aarch64|arm64)
+        NODE_ARCH="arm64"
+        ;;
+    *)
+        NODE_ARCH="$ARCH"
+        ;;
+esac
+
+curl -L "https://nodejs.org/dist/v15.10.0/node-v15.10.0-linux-${NODE_ARCH}.tar.xz" -o node.tar.xz
 tar xf node.tar.xz --strip-components=1
 rm node.tar.xz

--- a/packages/node/16.3.0/build.sh
+++ b/packages/node/16.3.0/build.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
-curl "https://nodejs.org/dist/v16.3.0/node-v16.3.0-linux-x64.tar.xz" -o node.tar.xz
+set -e
+
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64)
+        NODE_ARCH="x64"
+        ;;
+    aarch64|arm64)
+        NODE_ARCH="arm64"
+        ;;
+    *)
+        NODE_ARCH="$ARCH"
+        ;;
+esac
+
+curl -L "https://nodejs.org/dist/v16.3.0/node-v16.3.0-linux-${NODE_ARCH}.tar.xz" -o node.tar.xz
 tar xf node.tar.xz --strip-components=1
 rm node.tar.xz

--- a/packages/node/18.15.0/build.sh
+++ b/packages/node/18.15.0/build.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
-curl "https://nodejs.org/dist/v18.15.0/node-v18.15.0-linux-x64.tar.xz" -o node.tar.xz
+set -e
+
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64)
+        NODE_ARCH="x64"
+        ;;
+    aarch64|arm64)
+        NODE_ARCH="arm64"
+        ;;
+    *)
+        NODE_ARCH="$ARCH"
+        ;;
+esac
+
+curl -L "https://nodejs.org/dist/v18.15.0/node-v18.15.0-linux-${NODE_ARCH}.tar.xz" -o node.tar.xz
 tar xf node.tar.xz --strip-components=1
 rm node.tar.xz

--- a/packages/node/20.11.1/build.sh
+++ b/packages/node/20.11.1/build.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
-curl "https://nodejs.org/dist/v20.11.1/node-v20.11.1-linux-x64.tar.xz" -o node.tar.xz
+set -e
+
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64)
+        NODE_ARCH="x64"
+        ;;
+    aarch64|arm64)
+        NODE_ARCH="arm64"
+        ;;
+    *)
+        NODE_ARCH="$ARCH"
+        ;;
+esac
+
+curl -L "https://nodejs.org/dist/v20.11.1/node-v20.11.1-linux-${NODE_ARCH}.tar.xz" -o node.tar.xz
 tar xf node.tar.xz --strip-components=1
 rm node.tar.xz

--- a/packages/rust/1.50.0/build.sh
+++ b/packages/rust/1.50.0/build.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
+set -e
 
-curl -OL "https://static.rust-lang.org/dist/rust-1.50.0-x86_64-unknown-linux-gnu.tar.gz"
-tar xzvf rust-1.50.0-x86_64-unknown-linux-gnu.tar.gz
-rm rust-1.50.0-x86_64-unknown-linux-gnu.tar.gz
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64)
+        RUST_ARCH="x86_64"
+        ;;
+    aarch64|arm64)
+        RUST_ARCH="aarch64"
+        ;;
+    *)
+        RUST_ARCH="$ARCH"
+        ;;
+esac
+
+curl -OL "https://static.rust-lang.org/dist/rust-1.50.0-${RUST_ARCH}-unknown-linux-gnu.tar.gz"
+tar xzvf rust-1.50.0-${RUST_ARCH}-unknown-linux-gnu.tar.gz
+rm rust-1.50.0-${RUST_ARCH}-unknown-linux-gnu.tar.gz

--- a/packages/rust/1.56.1/build.sh
+++ b/packages/rust/1.56.1/build.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
+set -e
 
-curl -OL "https://static.rust-lang.org/dist/rust-1.56.1-x86_64-unknown-linux-gnu.tar.gz"
-tar xzvf rust-1.56.1-x86_64-unknown-linux-gnu.tar.gz
-rm rust-1.56.1-x86_64-unknown-linux-gnu.tar.gz
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64)
+        RUST_ARCH="x86_64"
+        ;;
+    aarch64|arm64)
+        RUST_ARCH="aarch64"
+        ;;
+    *)
+        RUST_ARCH="$ARCH"
+        ;;
+esac
+
+curl -OL "https://static.rust-lang.org/dist/rust-1.56.1-${RUST_ARCH}-unknown-linux-gnu.tar.gz"
+tar xzvf rust-1.56.1-${RUST_ARCH}-unknown-linux-gnu.tar.gz
+rm rust-1.56.1-${RUST_ARCH}-unknown-linux-gnu.tar.gz

--- a/packages/rust/1.62.0/build.sh
+++ b/packages/rust/1.62.0/build.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
+set -e
 
-curl -OL "https://static.rust-lang.org/dist/rust-1.62.0-x86_64-unknown-linux-gnu.tar.gz"
-tar xzvf rust-1.62.0-x86_64-unknown-linux-gnu.tar.gz
-rm rust-1.62.0-x86_64-unknown-linux-gnu.tar.gz
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64)
+        RUST_ARCH="x86_64"
+        ;;
+    aarch64|arm64)
+        RUST_ARCH="aarch64"
+        ;;
+    *)
+        RUST_ARCH="$ARCH"
+        ;;
+esac
+
+curl -OL "https://static.rust-lang.org/dist/rust-1.62.0-${RUST_ARCH}-unknown-linux-gnu.tar.gz"
+tar xzvf rust-1.62.0-${RUST_ARCH}-unknown-linux-gnu.tar.gz
+rm rust-1.62.0-${RUST_ARCH}-unknown-linux-gnu.tar.gz

--- a/packages/rust/1.63.0/build.sh
+++ b/packages/rust/1.63.0/build.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
+set -e
 
-curl -OL "https://static.rust-lang.org/dist/rust-1.63.0-x86_64-unknown-linux-gnu.tar.gz"
-tar xzvf rust-1.63.0-x86_64-unknown-linux-gnu.tar.gz
-rm rust-1.63.0-x86_64-unknown-linux-gnu.tar.gz
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64)
+        RUST_ARCH="x86_64"
+        ;;
+    aarch64|arm64)
+        RUST_ARCH="aarch64"
+        ;;
+    *)
+        RUST_ARCH="$ARCH"
+        ;;
+esac
+
+curl -OL "https://static.rust-lang.org/dist/rust-1.63.0-${RUST_ARCH}-unknown-linux-gnu.tar.gz"
+tar xzvf rust-1.63.0-${RUST_ARCH}-unknown-linux-gnu.tar.gz
+rm rust-1.63.0-${RUST_ARCH}-unknown-linux-gnu.tar.gz

--- a/packages/rust/1.65.0/build.sh
+++ b/packages/rust/1.65.0/build.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
+set -e
 
-curl -OL "https://static.rust-lang.org/dist/rust-1.65.0-x86_64-unknown-linux-gnu.tar.gz"
-tar xzvf rust-1.65.0-x86_64-unknown-linux-gnu.tar.gz
-rm rust-1.65.0-x86_64-unknown-linux-gnu.tar.gz
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64)
+        RUST_ARCH="x86_64"
+        ;;
+    aarch64|arm64)
+        RUST_ARCH="aarch64"
+        ;;
+    *)
+        RUST_ARCH="$ARCH"
+        ;;
+esac
+
+curl -OL "https://static.rust-lang.org/dist/rust-1.65.0-${RUST_ARCH}-unknown-linux-gnu.tar.gz"
+tar xzvf rust-1.65.0-${RUST_ARCH}-unknown-linux-gnu.tar.gz
+rm rust-1.65.0-${RUST_ARCH}-unknown-linux-gnu.tar.gz

--- a/packages/rust/1.68.2/build.sh
+++ b/packages/rust/1.68.2/build.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
+set -e
 
-curl -OL "https://static.rust-lang.org/dist/rust-1.68.2-x86_64-unknown-linux-gnu.tar.gz"
-tar xzvf rust-1.68.2-x86_64-unknown-linux-gnu.tar.gz
-rm rust-1.68.2-x86_64-unknown-linux-gnu.tar.gz
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64)
+        RUST_ARCH="x86_64"
+        ;;
+    aarch64|arm64)
+        RUST_ARCH="aarch64"
+        ;;
+    *)
+        RUST_ARCH="$ARCH"
+        ;;
+esac
+
+curl -OL "https://static.rust-lang.org/dist/rust-1.68.2-${RUST_ARCH}-unknown-linux-gnu.tar.gz"
+tar xzvf rust-1.68.2-${RUST_ARCH}-unknown-linux-gnu.tar.gz
+rm rust-1.68.2-${RUST_ARCH}-unknown-linux-gnu.tar.gz

--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,16 @@ docker-compose up -d api
 cd cli && npm i && cd -
 ```
 
+#### Apple Silicon
+
+The published Docker image only targets `amd64`. If you're using an
+Apple Silicon (arm64) machine, build the API image locally with
+`docker-compose.dev.yaml`:
+
+```sh
+docker compose -f docker-compose.dev.yaml up -d api
+```
+
 The API will now be online with no language runtimes installed. To install runtimes, [use the CLI](#cli).
 
 ## Just Piston (no CLI)

--- a/repo/Dockerfile
+++ b/repo/Dockerfile
@@ -1,9 +1,10 @@
 FROM debian:buster-slim
+ARG TARGETARCH
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y unzip autoconf build-essential libssl-dev \
         pkg-config zlib1g-dev libargon2-dev libsodium-dev libcurl4-openssl-dev \
         sqlite3 libsqlite3-dev libonig-dev libxml2 libxml2-dev bc curl git \
-        linux-headers-amd64 perl xz-utils python3 python3-pip gnupg jq zlib1g-dev \
+        linux-headers-${TARGETARCH:-amd64} perl xz-utils python3 python3-pip gnupg jq zlib1g-dev \
         cmake cmake-doc extra-cmake-modules build-essential gcc binutils bash coreutils \
         util-linux pciutils usbutils coreutils binutils findutils grep libncurses5-dev \
         libncursesw5-dev python3-pip libgmp-dev libmpfr-dev python2 libffi-dev gfortran\


### PR DESCRIPTION
## Summary
- support arm64 downloads for Node.js, Go, Haskell and Rust build scripts
- allow repo Dockerfile to choose correct `linux-headers-*`
- document how Apple Silicon users can build the API image

## Testing
- `./pre-commit`

------
https://chatgpt.com/codex/tasks/task_b_6857f586eb788328b63400096432549a